### PR TITLE
bug fix in TeamsViewController

### DIFF
--- a/croco/Screens/Teams/TeamTableViewCell.swift
+++ b/croco/Screens/Teams/TeamTableViewCell.swift
@@ -110,11 +110,7 @@ class TeamTableViewCell: UITableViewCell {
         deleteTeamButton.addTarget(self, action: #selector(deleteTeam), for: .touchUpInside)
     }
     
-    @objc func deleteTeam() {
-        if let team = team {
-            TeamAPI.deleteTeam(team)
-        }
-        
+    @objc func deleteTeam() {        
         if let indexPath = indexPath, let deleteCallback = deleteCallback {
             deleteCallback(indexPath)
         }

--- a/croco/Screens/Teams/TeamsViewController.swift
+++ b/croco/Screens/Teams/TeamsViewController.swift
@@ -106,6 +106,8 @@ extension TeamsViewController: UITableViewDataSource {
     }
     
     @objc func deleteTeam(indexPath: IndexPath) {
+        guard indexPath.row < teams.count else { return }
+        TeamAPI.deleteTeam(teams[indexPath.row])
         print("look on index path \(indexPath.row)")
         teams.remove(at: indexPath.row)
         teamsTable.tableView.beginUpdates()
@@ -129,11 +131,7 @@ extension TeamsViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            teams.remove(at: indexPath.row)
-            teamsTable.tableView.beginUpdates()
-            teamsTable.tableView.deleteRows(at: [indexPath], with: .automatic)
-            teamsTable.tableView.endUpdates()
-            teamsTable.tableView.reloadData()
+            deleteTeam(indexPath: indexPath)
         }
     }
 


### PR DESCRIPTION
Пофиксил баг на экране выбора команд: при удалении команды свайп-методом данные не синхронизируются с сервисом (на лидерборде не удалялась соответствующая команда)